### PR TITLE
Remove babel from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "url": "git@github.com:bullhorn/bullhornjs.git"
   },
   "devDependencies": {
-    "babel": "^6.23.0",
-    "babel-cli": "^6.24.0",
+    "babel-cli": "^6.26.0",
     "babel-core": "^6.24.0",
     "babel-jest": "^6.0.1",
     "babel-plugin-external-helpers": "^6.22.0",


### PR DESCRIPTION
Newer babel-cli requires that babel is not a dependency